### PR TITLE
chore: release v0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.1](https://github.com/Karthik-d-k/robot-hat-rs/releases/tag/v0.0.1) - 2023-11-17
+
+### Other
+- update Cargo.toml
+- delete old action file, bcz not working
+- Update rust.yml
+- Create rust.yml
+- update ci.yml
+- Update ci.yml
+- update docs
+- Create ci.yml
+- update docs
+- impl pin abstraction for robot-hat pins
+- add initial ultrasonic impl
+- create cargo lib
+- Update README.md
+- Create LICENSE-APACHE
+- Create LICENSE-MIT
+- Initial commit


### PR DESCRIPTION
## 🤖 New release
* `robot-hat-rs`: 0.0.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.1](https://github.com/Karthik-d-k/robot-hat-rs/releases/tag/v0.0.1) - 2023-11-17

### Other
- update Cargo.toml
- delete old action file, bcz not working
- Update rust.yml
- Create rust.yml
- update ci.yml
- Update ci.yml
- update docs
- Create ci.yml
- update docs
- impl pin abstraction for robot-hat pins
- add initial ultrasonic impl
- create cargo lib
- Update README.md
- Create LICENSE-APACHE
- Create LICENSE-MIT
- Initial commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).