### PR TITLE
chore: release v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3](https://github.com/Karthik-d-k/robot-hat-rs/compare/v0.0.2...v0.0.3) - 2023-12-22
+
+### Other
+- add grayscale impl
+- add adc module
+
 ## [0.0.2](https://github.com/Karthik-d-k/robot-hat-rs/compare/v0.0.1...v0.0.2) - 2023-11-19
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "robot-hat-rs"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 authors = ["Karthik D K <karthikdk1998@gmail.com>"]
 categories = ["embedded"]


### PR DESCRIPTION
## 🤖 New release
* `robot-hat-rs`: 0.0.2 -> 0.0.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.3](https://github.com/Karthik-d-k/robot-hat-rs/compare/v0.0.2...v0.0.3) - 2023-12-22

### Other
- add grayscale impl
- add adc module
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).